### PR TITLE
Update Version Tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ jobs:
         with:
           dotnet-version: "3.1.300"
       - name: Generate Documentation
-        uses: FuLagann/csharp-docs-generator@v1
+        uses: FuLagann/csharp-docs-generator@v1.0
         with:
           build-tasks: dotnet build
           cleanup-tasks: dotnet clean


### PR DESCRIPTION
Correct Tag is `v1.0`. Using `v1` hits an error.